### PR TITLE
Removed Void Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ _Operating Systems and Linux distributions._
 - [Solus](https://www.patreon.com/solus) - Linux distribution. 
 - [Ubuntu Mate](https://www.patreon.com/ubuntu_mate) - Ubuntu variant. 
 - [Ubuntu Touch](https://www.patreon.com/ubports) - Touch-friendly mobile version of Ubuntu.
-- [Void Linux](https://www.patreon.com/xtraeme) - Linux distribution.
 
 ### Bots
 _Bots!_


### PR DESCRIPTION
The Patreon is for Juan RP, but he has [gone missing](https://voidlinux.org/news/2018/05/serious-issues.html). I think we should remove it for now. If Void later opens a new funding channel, we can add it.